### PR TITLE
Fix for supporting different queues

### DIFF
--- a/src/contextmenus.js
+++ b/src/contextmenus.js
@@ -13,6 +13,8 @@ chrome.contextMenus.onClicked.addListener(contextMenuHandler);
 
 function contextMenuHandler(info, tab) {
     if (info.menuItemId === contextMenus.findMessagesOnQueue) {
-        findMessages();
+        
+		findMessagesWithDynamicQueueNames();
+		//findMessages();
     }
 }

--- a/src/findMessages.js
+++ b/src/findMessages.js
@@ -1,8 +1,43 @@
-function findMessages() {
+
+/*Function triggered from context menu*/
+function findMessagesWithDynamicQueueNames()
+{
+	
+	/*Function requests the queue name from the tab 
+	  Also BROWSES the message in the queue
+	  #I would prefer to do this without a call back#
+	 */
+	getQueueFromPageAndProcessMessages(); 
+
+}
+
+
+
+function getQueueFromPageAndProcessMessages(){
+
+	/*Request sent to chrome tab to scrape the QUEUE name.
+	  Call back triggers the findMessages(dynamicQueueName). 
+	*/
+	
+	chrome.tabs.query({active: true, currentWindow: true}, 
+			function(tabs) {
+			  chrome.tabs.sendMessage(tabs[0].id, {action: "extractQueueName"}, function(response) {
+				console.log('Response on QUEUE NAME: '+response.queueNameonPage);
+				findMessages(response.queueNameonPage);
+			  });
+			});
+
+	
+}
+
+
+function findMessages(dynamicQueueName) {
+	console.log('findMessages executed - on QUEUE NAME: '+dynamicQueueName);
     var factoryProps = new solace.SolclientFactoryProperties();
     factoryProps.profile = solace.SolclientFactoryProfiles.version10;
     solace.SolclientFactory.init(factoryProps);
-    queueName = localStorage.getItem('queuename');
+    //queueName = localStorage.getItem('queuename');
+	queueName = dynamicQueueName;
     var session = solace.SolclientFactory.createSession({
         url: localStorage.getItem('solaceURL'),
         vpnName: localStorage.getItem('solaceVpnName'),

--- a/src/inject/inject.js
+++ b/src/inject/inject.js
@@ -13,4 +13,26 @@ chrome.runtime.onMessage.addListener(
 				farewell: request.action
 			});
 		}
+		
+		
+		if (request.action === "extractQueueName")
+		{
+		  var datarow = document.getElementsByClassName('title title-content detail-title-width ellipsis-data');
+		  var rawQueueName =  datarow[0].innerHTML;
+		  console.log('RAW QUEUE NAME on PAGE: '+rawQueueName);
+		  var processedQueueName = transformRawQueueName(rawQueueName);
+		  console.log('PROCESSED QUEUE NAME on PAGE: '+processedQueueName);
+		  sendResponse({queueNameonPage: processedQueueName});
+		}		
+		
+		
 	});
+	
+	
+function transformRawQueueName(rawQueueName)
+{
+
+	/*The QUEUE name is represented in the tag <font color="#BFBFBF">Queues | </font> NAME OF THE QUEUE*/
+	return rawQueueName.substr(rawQueueName.indexOf('</font>')+7);
+
+}	

--- a/src/options/options.html
+++ b/src/options/options.html
@@ -15,10 +15,6 @@
         <input type="text" id="vpnName" />
       </div>
       <div class="teststyle2">
-        <span>queuename</span>
-        <input type="text" id="queuename"/>
-      </div>
-      <div class="teststyle2">
         <span>userName</span>
         <input type="text" id="userName" />        
       </div>

--- a/src/options/options.js
+++ b/src/options/options.js
@@ -3,14 +3,14 @@ function save_options() {
   localStorage.setItem('solaceVpnName', document.getElementById('vpnName').value);
   localStorage.setItem('solaceUserName', document.getElementById('userName').value);
   localStorage.setItem('solacePassword', document.getElementById('password').value);
-  localStorage.setItem('queuename', document.getElementById('queuename').value);
+  
 }
 function restore_options() {
   document.getElementById('solaceURL').value = localStorage.getItem('solaceURL') || '';
   document.getElementById('vpnName').value = localStorage.getItem('solaceVpnName') || '';
   document.getElementById('userName').value = localStorage.getItem('solaceUserName') || '';
   document.getElementById('password').value = localStorage.getItem('solacePassword') || '';
-  document.getElementById('queuename').value = localStorage.getItem('queuename') || '';
+  
 }
 document.addEventListener('DOMContentLoaded', restore_options);
 document.getElementById('save').addEventListener('click', save_options);


### PR DESCRIPTION
Hello,

I have removed the need to add/modify the **queue** in the configuration/settings page. 
Now the queue name is automatically scrapped from the page and used while browsing the queue.

Best Regards,
Franklin