### PR TITLE
Expanded allowed hostnames

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Solace Queue Message Viewer",
   "description": "View the content of messages on a queue directly in the Solace Event Broker UI.",
-  "version": "2.4.1",
+  "version": "2.4.2",
   "manifest_version": 3,
   "permissions": [
     "storage",
@@ -9,6 +9,8 @@
   ],
   "host_permissions": [
     "wss://*.messaging.solace.cloud:443/*",
+    "ws://*.local/*",
+    "wss://*.local/*",
     "ws://localhost/*",
     "wss://localhost/*"
   ],
@@ -28,6 +30,8 @@
     {
       "matches": [
         "https://*.messaging.solace.cloud:943/*",
+        "http://*.local/*",
+        "https://*.local/*",
         "http://localhost/*",
         "https://localhost/*"
       ],

--- a/src/findMessages.js
+++ b/src/findMessages.js
@@ -99,7 +99,7 @@ async function queryMessagesFromQueue(dynamicQueueName) {
         });
 
         // Get domain, port and protocol from URL using regex
-        const domainMatch = url.match(/^https:\/\/(.*).messaging.solace.cloud:\d+|^http(s?):\/\/localhost:\d+/);
+        const domainMatch = url.match(/^https:\/\/(.*).messaging.solace.cloud:\d+|^http(s)?:\/\/(.*).local:\d+|^http(s?):\/\/localhost:\d+/);
         if (!domainMatch) {
             sendErrorToPage('URL Error', 'Could not extract domain from the current page URL.');
             return;

--- a/src/inject/inject.js
+++ b/src/inject/inject.js
@@ -1,6 +1,6 @@
 
 // --- Constants and Variables ---
-const QUEUE_MESSAGES_PAGE_PATTERN = /^https:\/\/.*\.messaging\.solace\.cloud:\d+\/.*\/endpoints\/queues\/.*\/messages.*?$|^http(s?):\/\/localhost:\d+\/.*\/endpoints\/queues\/.*\/messages.*?$/;
+const QUEUE_MESSAGES_PAGE_PATTERN = /^https:\/\/.*\.messaging\.solace\.cloud:\d+\/.*\/endpoints\/queues\/.*\/messages.*?$|^http(s)?:\/\/.*\.local:\d+\/.*\/endpoints\/queues\/.*\/messages.*?$|^http(s?):\/\/localhost:\d+\/.*\/endpoints\/queues\/.*\/messages.*?$/;
 const BUTTON_ID = 'findMsgsExtensionButtonId';
 const DELAY = 500; // Delay in ms for DOM checks
 

--- a/src/lib/sharedUtils.js
+++ b/src/lib/sharedUtils.js
@@ -4,7 +4,7 @@
  * @returns {boolean} - Returns true if the URL is valid, false otherwise.
  */
 export function isValidMsgVpnUrl(msgVpnUrl) { // <<< Added export
-    const regex = /^https:\/\/.*\.messaging\.solace\.cloud:\d+\/?$|^http(s?):\/\/localhost:\d+\/?$/;
+    const regex = /^https:\/\/.*\.messaging\.solace\.cloud:\d+\/?$|^https:\/\/.*\.local:\d+\/?$|^http(s?):\/\/localhost:\d+\/?$/;
     return regex.test(msgVpnUrl);
 }
 


### PR DESCRIPTION
Support for wss://[computername]:[secure ws port] and https://[computername]:[secure http port] added so developers can debug the secure connections on their local dev environment when using oauth SSO

Entra OAuth does not like it when you use localhost, and likes it with a computername like mycomputer.local
closes #32 