### PR TITLE
Proper handling of payload to fix display issues with json payloads in text format mode

### DIFF
--- a/src/findMessages.js
+++ b/src/findMessages.js
@@ -351,50 +351,6 @@ async function queryMessagesFromQueue(dynamicQueueName) {
     }
 }
 
-function getPayloadType(message) {
-    const type = message.getType();
-
-    if (type === solace.MessageType.BINARY) {
-        return "binary";
-    }
-
-    if (type === solace.MessageType.MAP) {
-        return "map";
-    }
-
-    if (type === solace.MessageType.STREAM) {
-        return "stream";
-    }
-
-    if (type === solace.MessageType.TEXT) {
-        return "text";
-    }
-
-    return "unknown";    
-}
-
-function getPayload(message) {
-    const type = message.getPayloadType();
-    const payload = null;
-    if (type === solace.MessagePayloadType.STRING) {
-        payload = message.getPayloadAsString();
-    }
-
-    if (type === solace.MessagePayloadType.BINARY) {
-        const bytes = message.getBinaryAttachment();
-        payload = new TextDecoder("utf-8").decode(bytes);
-    }
-
-    if (type === solace.MessagePayloadType.XML) {
-        payload = message.getXmlContent();
-    }
-
-    if (type === solace.MessagePayloadType.SDT_CONTAINER) {
-        payload = message.getSdtContainer();
-    }
-
-    return { type, payload };    
-}
 /**
  * Sends a message to the active page.
  *


### PR DESCRIPTION
Closes #34 This fix solves the proper display of json payloads in the broswer when json payloads are sent as text messages